### PR TITLE
Update tiffRead.m

### DIFF
--- a/tiffRead.m
+++ b/tiffRead.m
@@ -92,8 +92,15 @@ if nargout > 1
             end
             varargout{2} = s.scanimage;
         case 2016
-            siHeader = scanimage.util.opentif(fPath);
-            varargout{2} = siHeader;
+            info = imfinfo(fPath);
+            temp = info.Software;
+            ind = strfind(temp,'SI.');
+            temp(ind(2:end)-1) = ';';
+            temp(end) = ';';
+            eval(temp);
+            varargout{2} = SI;
+            % siHeader = scanimage.util.opentif(fPath);
+            % varargout{2} = siHeader;
         case -1
             % Not a scanimage file. Since a second output argument was
             % requested, we use a fake scanimage metadata to make the Acq2P


### PR DESCRIPTION
For SI2016 data, scanimage.util.opentif is not readily available? (I could not find it online...)
So I came up with workaround with MATLAB built-in function.
This might be easier for other people in the lab to use.